### PR TITLE
fix delete as a reserved word issue on IE8

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ if (typeof WeakMap === 'undefined') {
       return (entry = key[this.name]) && entry[0] === key ?
           entry[1] : undefined;
     },
-    delete: function(key) {
+    'delete': function(key) {
       var entry = key[this.name];
       if (!entry) return false;
       var hasValue = entry[0] === key;


### PR DESCRIPTION
I'm not sure how does `mutation-observer` support IE8, but we will get a js error whenever requiring `mutation-observer` on IE8, adding single quote to fix the error. 

@coreh @TooTallNate
