### PR TITLE
Fixed setting module.exports when it does not exist (e.g. when using this in IE10).

### DIFF
--- a/index.js
+++ b/index.js
@@ -582,4 +582,6 @@ if (!MutationObserver) {
   MutationObserver = JsMutationObserver;
 }
 
-module.exports = MutationObserver;
+if (typeof module !== 'undefined') {
+  module.exports = MutationObserver;
+}


### PR DESCRIPTION
If we include this polyfill on a vanilla page it will fail under IE10 because module is undefined. This change just adds a check to make sure module exists.
