### PR TITLE
Fixed setting module.exports when it does not exist (e.g. when using …

### DIFF
--- a/index.js
+++ b/index.js
@@ -582,4 +582,6 @@ if (!MutationObserver) {
   MutationObserver = JsMutationObserver;
 }
 
-module.exports = MutationObserver;
+if (typeof module !== 'undefined') {
+  module.exports = MutationObserver;
+}


### PR DESCRIPTION
…this in IE10).
