### PR TITLE
With the posibility of the MutationEvent being deprecated, check if exists prior to usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -487,8 +487,9 @@ Registration.prototype = {
         record.attributeNamespace = namespace;
 
         // 2.
-        var oldValue =
-            e.attrChange === MutationEvent.ADDITION ? null : e.prevValue;
+        var oldValue = null;
+        if (!(MutationEvent != 'undefined' && e.attrChange === MutationEvent.ADDITION))
+          oldValue = e.prevValue;
 
         forEachAncestorAndObserverEnqueueRecord(target, function(options) {
           // 3.1, 4.2

--- a/index.js
+++ b/index.js
@@ -488,7 +488,7 @@ Registration.prototype = {
 
         // 2.
         var oldValue = null;
-        if (!(MutationEvent != 'undefined' && e.attrChange === MutationEvent.ADDITION))
+        if (!(typeof MutationEvent !== 'undefined' && e.attrChange === MutationEvent.ADDITION))
           oldValue = e.prevValue;
 
         forEachAncestorAndObserverEnqueueRecord(target, function(options) {


### PR DESCRIPTION
Ran into an [isssue](https://github.com/cerner/xfc/issues/3) with a configuration of IE where the MutationEvent is no longer a valid Object.  With the notation of its [deprecation](https://msdn.microsoft.com/en-us/library/ff974346(v=vs.85).aspx), adding a check in case the client upgrades to a version no longer supporting the MutationEvent to keep this polyfill from throwing a javascript exception.  