### PR TITLE
Allow omission of `attributes` if `attributeOldValue` or `attributeFilter` is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,6 +190,11 @@ JsMutationObserver.prototype = {
   observe: function(target, options) {
     target = wrapIfNeeded(target);
 
+    var needsAttributes = options.hasOwnProperty('attributeOldValue') || options.hasOwnProperty('attributeFilter');
+    if (needsAttributes && !options.hasOwnProperty('attributes')) {
+      options.attributes = true;
+    }
+
     // 1.1
     if (!options.childList && !options.attributes && !options.characterData ||
 


### PR DESCRIPTION
Per the [whatwg standard](https://dom.spec.whatwg.org/#interface-mutationobserver), `attributes` has no default value in `MutationObserverInit` (i.e., not `false`).
Also, `attributes` should be set to `true` if implicitly `true` (i.e., `attributeOldValue` or `attributeFilter` is specified).

> The observe(target, options) method, when invoked, must run these steps:
> 1. If either options’s attributeOldValue or attributeFilter is present and options’s attributes is omitted, then set options’s attributes to true.

This PR will allow the omission of the `attributes` option if `attributeOldValue` or `attributeFilter` is specified.

___

Depending on your setup, you can work around this in the meantime by patching the `observe` method:

```js
const MutationObserver = require('mutation-observer');
const _observe = MutationObserver.prototype.observe;
MutationObserver.prototype.observe = function observe(target, options) {
  const needsAttributes = options.hasOwnProperty('attributeOldValue') || options.hasOwnProperty('attributeFilter');
  if (needsAttributes && !options.hasOwnProperty('attributes')) {
    options.attributes = true;
  }
  Function.prototype.call(_observe, this, target, options);
};
Object.defineProperty(window, 'MutationObserver', { value: MutationObserver });
```

(h/t @chandlerprall)